### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "main": "src/index.html",
     "license": "MIT",
     "scripts": {
-      "eslint": "eslint --ext .js src/ test/",
+      "eslint": "eslint --ext .js src/ test/"
     },
     "dependencies": {
       "eslint": "^5.9.0",


### PR DESCRIPTION
comma at the end of line 7 prevents the command 'npm install' from running. Removing it fixes the problem.